### PR TITLE
Use int64 for `Event.ID`

### DIFF
--- a/mpvipc.go
+++ b/mpvipc.go
@@ -48,7 +48,7 @@ type Event struct {
 	Text string `json:"text"`
 
 	// ID is the user-set property ID (on events triggered by observed properties)
-	ID uint `json:"id"`
+	ID int64 `json:"id"`
 
 	// Data is the property value (on events triggered by observed properties)
 	Data interface{} `json:"data"`


### PR DESCRIPTION
Observed property IDs are int64 in mpv[1].

Note: This is a breaking change.

[1]: https://github.com/mpv-player/mpv/blob/2a969a833f98b3486be8007972887c27c08b6f61/input/ipc.c#L251