### PR TITLE
increase scanner buffer size to allow for large IPC responses

### DIFF
--- a/mpvipc.go
+++ b/mpvipc.go
@@ -310,8 +310,11 @@ func (c *Connection) checkEvent(data []byte) {
 	c.eventHub.broadcast <- event
 }
 
+const maxScanTokenSize = 32 * 1024 * 1024 // 32MB
+
 func (c *Connection) listen() {
 	scanner := bufio.NewScanner(c.client)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxScanTokenSize)
 	for scanner.Scan() {
 		data := scanner.Bytes()
 		c.checkEvent(data)


### PR DESCRIPTION
bufio.Scanner defaults to 64KB max token size. some responses can exceed that limit, in which case scanner.Scan() stops and the connection is silently closed

raise the max token size to 32MB so large responses survive

see https://github.com/sentriz/gonic/issues/558